### PR TITLE
Add Intel XPU support with device-agnostic backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,37 @@ This repo is the official implementation of **$\tau_0$-World Model: A Unified Vi
 pip install -r requirements.txt
 ```
 
+### Device Selection
+
+The inference servers support CPU, NVIDIA CUDA, and Intel XPU (integrated and discrete GPUs) backends. Use the `--device` flag to select the target device:
+
+| `--device` | Backend | Distributed backend |
+|---|---|---|
+| `xpu` | Intel GPU (XPU) | `ccl` |
+| `cuda` | NVIDIA GPU (CUDA) | `nccl` |
+| `cpu` | CPU | `gloo` |
+| *(omit)* | Auto-detect (xpu > cuda > cpu) | — |
+
+**Intel XPU** — install a PyTorch build with XPU support, then launch the server with `--device xpu`:
+
+```
+python -m web_infer_utils.server \
+    --config configs/deployment/tau_pretrain_rela_eef6d.yaml \
+    --host $HOST --port $PORT \
+    --device xpu
+```
+
+**NVIDIA CUDA** — the default when CUDA is available; explicit flag shown for clarity:
+
+```
+python -m web_infer_utils.server \
+    --config configs/deployment/tau_pretrain_rela_eef6d.yaml \
+    --host $HOST --port $PORT \
+    --device cuda
+```
+
+The same `--device` flag applies to the post-training inference server (`web_infer_utils.posttrain_taco_play.server`). When the flag is omitted the best available device is selected automatically.
+
 ### Preparation
 
 1. Download the pretrained weight of $\tau_0$-World Model.

--- a/models/wan_2_2_models/pipeline/textimage2video.py
+++ b/models/wan_2_2_models/pipeline/textimage2video.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from functools import partial
 
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
 from PIL import Image
@@ -110,9 +109,39 @@ def masks_like_raw(tensor, zero=False, generator=None, p=0.2):
     return out1, out2
 
 
-def sync_current_cuda():
-    if torch.cuda.is_available():
+def sync_current_device(device=None):
+    if device is not None:
+        device_type = device.type if isinstance(device, torch.device) else str(device)
+    elif torch.xpu.is_available():
+        device_type = "xpu"
+    elif torch.cuda.is_available():
+        device_type = "cuda"
+    else:
+        return
+    if device_type == "xpu":
+        torch.xpu.synchronize()
+    elif device_type == "cuda":
         torch.cuda.synchronize()
+
+
+# Keep legacy alias
+def sync_current_cuda():
+    sync_current_device()
+
+
+def _empty_device_cache(device=None):
+    """Device-agnostic cache flush (XPU / CUDA)."""
+    device_type = None
+    if device is not None:
+        device_type = device.type if isinstance(device, torch.device) else str(device).split(":")[0]
+    elif torch.xpu.is_available():
+        device_type = "xpu"
+    elif torch.cuda.is_available():
+        device_type = "cuda"
+    if device_type == "xpu":
+        torch.xpu.empty_cache()
+    elif device_type == "cuda":
+        torch.cuda.empty_cache()
 
 
 class WanTI2V:
@@ -154,7 +183,12 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        if torch.xpu.is_available():
+            self.device = torch.device(f"xpu:{device_id}")
+        elif torch.cuda.is_available():
+            self.device = torch.device(f"cuda:{device_id}")
+        else:
+            self.device = torch.device("cpu")
         self.rank = rank
         self.t5_cpu = t5_cpu
         self.init_on_cpu = init_on_cpu
@@ -372,7 +406,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                torch.amp.autocast(self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):
@@ -430,7 +464,7 @@ class WanTI2V:
 
             if offload_model or self.init_on_cpu:
                 self.model.to(self.device)
-                torch.cuda.empty_cache()
+                _empty_device_cache(self.device)
 
             video_states_buffer = None
 
@@ -459,14 +493,14 @@ class WanTI2V:
                     noise_pred_cond = self.model(
                         latent_model_input, t=timestep, return_action=False, store_buffer=False, **arg_c)['video'][0]
                     if offload_model:
-                        torch.cuda.empty_cache()
+                        _empty_device_cache(self.device)
 
                     mark_compile_step_begin()
 
                     noise_pred_uncond = self.model(
                         latent_model_input, t=timestep, return_action=False, store_buffer=False, **arg_null)['video'][0]
                     if offload_model:
-                        torch.cuda.empty_cache()
+                        _empty_device_cache(self.device)
                     noise_pred = noise_pred_uncond + guide_scale * (
                         noise_pred_cond - noise_pred_uncond)
 
@@ -515,7 +549,7 @@ class WanTI2V:
                         **arg_c,
                     )
                     if offload_model:
-                        torch.cuda.empty_cache()
+                        _empty_device_cache(self.device)
 
                     action_states = sample_scheduler.step(
                         noise_pred['action'],
@@ -530,8 +564,8 @@ class WanTI2V:
             
             if offload_model:
                 self.model.cpu()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
+                sync_current_device(self.device)
+                _empty_device_cache(self.device)
 
             if return_video:
                 if self.rank == 0:
@@ -541,7 +575,7 @@ class WanTI2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            sync_current_device(self.device)
         # if dist.is_initialized():
         #     dist.barrier()
         if return_dict:
@@ -653,7 +687,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                torch.amp.autocast(self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):
@@ -744,7 +778,7 @@ class WanTI2V:
 
             if offload_model or self.init_on_cpu:
                 self.model.to(self.device)
-                torch.cuda.empty_cache()
+                _empty_device_cache(self.device)
 
             video_states_buffer = None
 
@@ -772,14 +806,14 @@ class WanTI2V:
                 video_out = self.model(
                     latent_model_input, t=timestep, return_action=False, store_buffer=store_buffer, **arg_c)
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    _empty_device_cache(self.device)
 
                 mark_compile_step_begin()
 
                 # noise_pred_uncond = self.model(
                 #     latent_model_input, t=timestep, return_action=False, store_buffer=False, **arg_null)['video'][0]
                 # if offload_model:
-                #     torch.cuda.empty_cache()
+                #     _empty_device_cache(self.device)
                 # noise_pred = noise_pred_uncond + guide_scale * (
                 #     noise_pred_cond - noise_pred_uncond)
 
@@ -834,7 +868,7 @@ class WanTI2V:
                     **arg_c,
                 )
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    _empty_device_cache(self.device)
 
                 action_states = sample_scheduler.step(
                     noise_pred['action'],
@@ -848,8 +882,8 @@ class WanTI2V:
             
             if offload_model:
                 self.model.cpu()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
+                sync_current_device(self.device)
+                _empty_device_cache(self.device)
 
             if self.rank == 0:
                 x0 = list(torch.cat([rearrange(x, "c t h (v w) -> v c t h w", v=V) for x in x0], dim=0).unbind(dim=0))
@@ -859,7 +893,7 @@ class WanTI2V:
         del noise, latent, x0
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            sync_current_device(self.device)
         # if dist.is_initialized():
         #     dist.barrier()
         if self.rank == 0:

--- a/models/wan_2_2_models/text_encoder/t5.py
+++ b/models/wan_2_2_models/text_encoder/t5.py
@@ -475,11 +475,18 @@ class T5EncoderModel:
         self,
         text_len,
         dtype=torch.bfloat16,
-        device=torch.cuda.current_device(),
+        device=None,
         checkpoint_path=None,
         tokenizer_path=None,
         shard_fn=None,
     ):
+        if device is None:
+            if torch.xpu.is_available():
+                device = torch.device("xpu", torch.xpu.current_device())
+            elif torch.cuda.is_available():
+                device = torch.device("cuda", torch.cuda.current_device())
+            else:
+                device = torch.device("cpu")
         self.text_len = text_len
         self.dtype = dtype
         self.device = device

--- a/models/wan_2_2_models/transformers/attention.py
+++ b/models/wan_2_2_models/transformers/attention.py
@@ -105,7 +105,7 @@ def flash_attention(
     """
     half_dtypes = (torch.float16, torch.bfloat16)
     assert dtype in half_dtypes
-    assert q.device.type == 'cuda' and q.size(-1) <= 256
+    assert q.device.type in ('cuda', 'xpu') and q.size(-1) <= 256
 
     # params
     b, lq, lk, out_dtype = q.size(0), q.size(1), k.size(1), q.dtype
@@ -197,7 +197,7 @@ def attention(
     causal=False,
     window_size=(-1, -1),
     deterministic=False,
-    dtype=torch.bfloat16,
+    dtype=None,
     fa_version=None,
 ):
     use_sdpa = _ATTENTION_IMPL == "sdpa"
@@ -250,9 +250,11 @@ def attention(
             )
         attn_mask = None
 
-        q = q.transpose(1, 2).to(dtype)
-        k = k.transpose(1, 2).to(dtype)
-        v = v.transpose(1, 2).to(dtype)
+        # Use input tensor dtype if no explicit dtype given (preserves float32 on non-CUDA devices)
+        effective_dtype = dtype if dtype is not None else q.dtype
+        q = q.transpose(1, 2).to(effective_dtype)
+        k = k.transpose(1, 2).to(effective_dtype)
+        v = v.transpose(1, 2).to(effective_dtype)
 
         if q_scale is not None:
             q = q * q_scale

--- a/models/wan_2_2_models/transformers/model.py
+++ b/models/wan_2_2_models/transformers/model.py
@@ -13,6 +13,15 @@ from models.wan_2_2_models.transformers.attention import flash_attention, attent
 __all__ = ['WanModel']
 
 
+def _device_type(tensor_or_device):
+    """Return the device type string ('xpu', 'cuda', 'cpu') for autocast."""
+    if isinstance(tensor_or_device, torch.device):
+        return tensor_or_device.type
+    if isinstance(tensor_or_device, torch.Tensor):
+        return tensor_or_device.device.type
+    return str(tensor_or_device)
+
+
 def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
@@ -374,7 +383,7 @@ class WanAttentionBlock(nn.Module):
             freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
         """
         assert e.dtype == torch.float32
-        with torch.amp.autocast('cuda', dtype=torch.float32):
+        with torch.amp.autocast(_device_type(e), dtype=torch.float32):
             e = (self.modulation.unsqueeze(0) + e).chunk(6, dim=2)
         assert e[0].dtype == torch.float32
 
@@ -382,7 +391,7 @@ class WanAttentionBlock(nn.Module):
         y = self.self_attn(
             self.norm1(x).float() * (1 + e[1].squeeze(2)) + e[0].squeeze(2),
             seq_lens, grid_sizes, freqs, precomputed_freqs=self_attn_precomputed_freqs)
-        with torch.amp.autocast('cuda', dtype=torch.float32):
+        with torch.amp.autocast(_device_type(x), dtype=torch.float32):
             x = x + y * e[2].squeeze(2)
 
         new_cross_attn_kv = None
@@ -406,7 +415,7 @@ class WanAttentionBlock(nn.Module):
 
         y = self.ffn(
             self.norm2(x).float() * (1 + e[4].squeeze(2)) + e[3].squeeze(2))
-        with torch.amp.autocast('cuda', dtype=torch.float32):
+        with torch.amp.autocast(_device_type(x), dtype=torch.float32):
             x = x + y * e[5].squeeze(2)
         if return_cross_attn_kv:
             return x, new_cross_attn_kv
@@ -437,7 +446,7 @@ class Head(nn.Module):
             e(Tensor): Shape [B, L1, C]
         """
         assert e.dtype == torch.float32
-        with torch.amp.autocast('cuda', dtype=torch.float32):
+        with torch.amp.autocast(_device_type(x), dtype=torch.float32):
             e = (self.modulation.unsqueeze(0) + e.unsqueeze(2)).chunk(2, dim=2)
             x = (
                 self.head(
@@ -656,7 +665,7 @@ class WanModel(ModelMixin, ConfigMixin):
             # time embeddings
             if t.dim() == 1:
                 t = t.expand(t.size(0), seq_len)
-            with torch.amp.autocast('cuda', dtype=torch.float32):
+            with torch.amp.autocast(_device_type(device), dtype=torch.float32):
                 bt = t.size(0)
                 t = t.flatten()
                 e = self.time_embedding(
@@ -704,7 +713,7 @@ class WanModel(ModelMixin, ConfigMixin):
                 action_timestep = torch.cat((torch.zeros_like(action_timestep[:,0:1]), action_timestep), dim=1)
             action_states = self.action_proj_in(action_states)
             action_seq_len = action_states.shape[1]
-            with torch.amp.autocast('cuda', dtype=torch.float32):
+            with torch.amp.autocast(_device_type(device), dtype=torch.float32):
                 action_bt = action_timestep.size(0)
                 action_timestep = action_timestep.flatten()
                 action_e = self.action_time_embedding(

--- a/models/wan_2_2_models/vae/vae2_2.py
+++ b/models/wan_2_2_models/vae/vae2_2.py
@@ -2,7 +2,6 @@
 import logging
 
 import torch
-import torch.cuda.amp as amp
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
@@ -10,6 +9,24 @@ from einops import rearrange
 __all__ = [
     "Wan2_2_VAE",
 ]
+
+
+def _device_type(device):
+    """Return the device type string ('xpu', 'cuda', 'cpu') for autocast."""
+    if isinstance(device, torch.device):
+        return device.type
+    return str(device).split(":")[0]
+
+
+def _resolve_device(device):
+    """Auto-detect the best available device when device is None."""
+    if device is None:
+        if torch.xpu.is_available():
+            return "xpu"
+        if torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+    return device
 
 CACHE_T = 2
 
@@ -895,11 +912,11 @@ class Wan2_2_VAE:
         dim_mult=[1, 2, 4, 4],
         temperal_downsample=[False, True, True],
         dtype=torch.float,
-        device="cuda",
+        device=None,
     ):
 
         self.dtype = dtype
-        self.device = device
+        self.device = _resolve_device(device)
 
         mean = torch.tensor(
             [
@@ -1025,7 +1042,7 @@ class Wan2_2_VAE:
         try:
             if not isinstance(videos, list):
                 raise TypeError("videos should be a list")
-            with amp.autocast(dtype=self.dtype):
+            with torch.amp.autocast(_device_type(self.device), dtype=self.dtype):
                 return [
                     self.model.encode(u.unsqueeze(0),
                                       self.scale).float().squeeze(0)
@@ -1039,7 +1056,7 @@ class Wan2_2_VAE:
         try:
             if not isinstance(zs, list):
                 raise TypeError("zs should be a list")
-            with amp.autocast(dtype=self.dtype):
+            with torch.amp.autocast(_device_type(self.device), dtype=self.dtype):
                 return [
                     self.model.decode(u.unsqueeze(0),
                                       self.scale).float().clamp_(-1,
@@ -1061,11 +1078,11 @@ class Wan2_2_VAE_Batch:
         dim_mult=[1, 2, 4, 4],
         temperal_downsample=[False, True, True],
         dtype=torch.float,
-        device="cuda",
+        device=None,
     ):
 
         self.dtype = dtype
-        self.device = device
+        self.device = _resolve_device(device)
 
         mean = torch.tensor(
             [
@@ -1189,7 +1206,7 @@ class Wan2_2_VAE_Batch:
 
     def encode(self, videos, chunk=1):
         try:
-            with amp.autocast(dtype=self.dtype):
+            with torch.amp.autocast(_device_type(self.device), dtype=self.dtype):
                 if chunk is None or chunk <= 1:
                     return [
                         self.model.encode(u.unsqueeze(0), self.scale).float().squeeze(0)
@@ -1214,7 +1231,7 @@ class Wan2_2_VAE_Batch:
         try:
             if not isinstance(zs, list):
                 raise TypeError("zs should be a list")
-            with amp.autocast(dtype=self.dtype):
+            with torch.amp.autocast(_device_type(self.device), dtype=self.dtype):
                 return [
                     self.model.decode(u.unsqueeze(0),
                                       self.scale).float().clamp_(-1,

--- a/runner/posttrain.py
+++ b/runner/posttrain.py
@@ -221,7 +221,8 @@ class Trainer:
         self.args.ddp_kwargs = ddp_config
         ddp_kwargs = DistributedDataParallelKwargs(**ddp_config)
         init_process_group_kwargs = InitProcessGroupKwargs(
-            backend="nccl", timeout=timedelta(seconds=self.args.nccl_timeout)
+            backend="ccl" if torch.xpu.is_available() else "nccl",
+            timeout=timedelta(seconds=self.args.nccl_timeout)
         )
         mixed_precision = "no" if torch.backends.mps.is_available() else self.args.mixed_precision
         report_to = None if self.args.report_to.lower() == "none" else self.args.report_to
@@ -495,7 +496,7 @@ class Trainer:
             self.diffusion_model.enable_gradient_checkpointing()
 
         # Enable TF32 for faster training on Ampere GPUs: https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
-        if self.args.allow_tf32 and torch.cuda.is_available():
+        if self.args.allow_tf32 and torch.cuda.is_available() and not torch.xpu.is_available():
             torch.backends.cuda.matmul.allow_tf32 = True
 
 
@@ -1016,7 +1017,7 @@ class Trainer:
             cap = 'Validation'
             fps = int(int(getattr(self.args, "basic_fps", 30)) / ((action_chunk-1)/(chunk-1)))
 
-            device_id = str(accelerator.device).lower().replace("cuda:", "")
+            device_id = str(accelerator.device).lower().replace("cuda:", "").replace("xpu:", "")
 
             save_video(rearrange(video.data.cpu(), 'c v t h w -> c t h (v w)', v=n_view), os.path.join(model_save_dir, f'{cap}_gt_{device_id}.mp4'), fps=fps)
 

--- a/utils/memory_utils.py
+++ b/utils/memory_utils.py
@@ -15,7 +15,14 @@ def get_memory_statistics(precision: int = 3) -> Dict[str, Any]:
     max_memory_allocated = None
     max_memory_reserved = None
 
-    if torch.cuda.is_available():
+    if torch.xpu.is_available():
+        device = torch.xpu.current_device()
+        memory_allocated = torch.xpu.memory_allocated(device)
+        memory_reserved = torch.xpu.memory_reserved(device)
+        max_memory_allocated = torch.xpu.max_memory_allocated(device)
+        max_memory_reserved = torch.xpu.max_memory_reserved(device)
+
+    elif torch.cuda.is_available():
         device = torch.cuda.current_device()
         memory_allocated = torch.cuda.memory_allocated(device)
         memory_reserved = torch.cuda.memory_reserved(device)
@@ -26,7 +33,7 @@ def get_memory_statistics(precision: int = 3) -> Dict[str, Any]:
         memory_allocated = torch.mps.current_allocated_memory()
 
     else:
-        logger.warning("No CUDA, MPS, or ROCm device found. Memory statistics are not available.")
+        logger.warning("No XPU, CUDA, MPS, or ROCm device found. Memory statistics are not available.")
 
     return {
         "memory_allocated": round(bytes_to_gigabytes(memory_allocated), ndigits=precision),
@@ -42,7 +49,10 @@ def bytes_to_gigabytes(x: int) -> float:
 
 
 def free_memory() -> None:
-    if torch.cuda.is_available():
+    if torch.xpu.is_available():
+        gc.collect()
+        torch.xpu.empty_cache()
+    elif torch.cuda.is_available():
         gc.collect()
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()

--- a/web_infer_utils/TauPolicy.py
+++ b/web_infer_utils/TauPolicy.py
@@ -55,7 +55,7 @@ class TauPolicy:
     def __init__(
         self,
         config_file,
-        device = torch.device("cuda:0"),
+        device = None,
         rank=0,
         compile_model=False,
         compile_mode="reduce-overhead",
@@ -71,7 +71,14 @@ class TauPolicy:
     ):
         cd = load(open(config_file, "r"), Loader=Loader)
         args = argparse.Namespace(**cd)
-        
+
+        if device is None:
+            if torch.xpu.is_available():
+                device = torch.device("xpu", 0)
+            elif torch.cuda.is_available():
+                device = torch.device("cuda", 0)
+            else:
+                device = torch.device("cpu")
         self.device = device
         self.rank=rank
         self.compile_model = compile_model

--- a/web_infer_utils/posttrain_taco_play/TauPolicy.py
+++ b/web_infer_utils/posttrain_taco_play/TauPolicy.py
@@ -38,7 +38,7 @@ class TauPolicy:
     def __init__(
         self,
         config_file,
-        device = torch.device("cuda:0"),
+        device = None,
         rank=0,
         compile_model=False,
         compile_mode="reduce-overhead",
@@ -54,7 +54,14 @@ class TauPolicy:
     ):
         cd = load(open(config_file, "r"), Loader=Loader)
         args = argparse.Namespace(**cd)
-        
+
+        if device is None:
+            if torch.xpu.is_available():
+                device = torch.device("xpu", 0)
+            elif torch.cuda.is_available():
+                device = torch.device("cuda", 0)
+            else:
+                device = torch.device("cpu")
         self.device = device
         self.rank=rank
         self.compile_model = compile_model

--- a/web_infer_utils/posttrain_taco_play/server.py
+++ b/web_infer_utils/posttrain_taco_play/server.py
@@ -19,7 +19,21 @@ from web_infer_utils.posttrain_taco_play.TauPolicy import TauPolicy
 logger = logging.getLogger(__name__)
 
 
-def init_distributed_and_get_device(backend: str = "nccl"):
+def init_distributed_and_get_device(backend: str = "nccl", device_type: str = None):
+    """
+    Args:
+        backend: distributed backend to use for CUDA (default 'nccl').
+        device_type: override device type ('xpu', 'cuda', 'cpu').
+                     Auto-detects the best available when None.
+    """
+    if device_type is None:
+        if torch.xpu.is_available():
+            device_type = "xpu"
+        elif torch.cuda.is_available():
+            device_type = "cuda"
+        else:
+            device_type = "cpu"
+
     is_distributed = False
     rank = 0
     local_rank = 0
@@ -30,7 +44,11 @@ def init_distributed_and_get_device(backend: str = "nccl"):
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        if torch.cuda.is_available():
+        if device_type == "xpu":
+            torch.xpu.set_device(local_rank)
+            device = torch.device("xpu", local_rank)
+            dist_backend = "ccl"
+        elif device_type == "cuda":
             torch.cuda.set_device(local_rank)
             device = torch.device("cuda", local_rank)
             dist_backend = backend
@@ -40,7 +58,10 @@ def init_distributed_and_get_device(backend: str = "nccl"):
         if not dist.is_initialized():
             dist.init_process_group(backend=dist_backend, init_method="env://")
     else:
-        if torch.cuda.is_available():
+        if device_type == "xpu":
+            device = torch.device("xpu", 0)
+            torch.xpu.set_device(device)
+        elif device_type == "cuda":
             device = torch.device("cuda", 0)
             torch.cuda.set_device(device)
         else:
@@ -126,13 +147,19 @@ def get_args():
     parser.add_argument("--sdpa-backend", type=str, default="auto", choices=["auto", "flash", "efficient", "math", "cudnn"])
     parser.add_argument("--flash-attn-version", type=str, default="auto", choices=["auto", "2", "3"])
     parser.add_argument("--disable-action-rope-cache", action="store_true")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device type: 'xpu', 'cuda', or 'cpu'. Auto-detects if not specified.",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = get_args()
     policy_metadata = dict(test_meta="Tau Posttrain Policy Meta Data")
-    device, is_distributed, rank, local_rank, world_size = init_distributed_and_get_device()
+    device, is_distributed, rank, local_rank, world_size = init_distributed_and_get_device(device_type=args.device)
     actor = TauPolicyServer(
         args.host,
         args.port,

--- a/web_infer_utils/server.py
+++ b/web_infer_utils/server.py
@@ -27,8 +27,13 @@ import os
 import sys
 
 
-def init_distributed_and_get_device(backend: str = "nccl"):
+def init_distributed_and_get_device(backend: str = "nccl", device_type: str = None):
     """
+    Args:
+        backend: distributed backend to use for CUDA (default 'nccl').
+        device_type: override device type ('xpu', 'cuda', 'cpu').
+                     Auto-detects the best available when None.
+
     return:
         device: torch.device
         is_distributed: bool
@@ -36,6 +41,14 @@ def init_distributed_and_get_device(backend: str = "nccl"):
         local_rank: int
         world_size: int
     """
+    if device_type is None:
+        if torch.xpu.is_available():
+            device_type = "xpu"
+        elif torch.cuda.is_available():
+            device_type = "cuda"
+        else:
+            device_type = "cpu"
+
     is_distributed = False
     rank = 0
     local_rank = 0
@@ -47,7 +60,11 @@ def init_distributed_and_get_device(backend: str = "nccl"):
         world_size = int(os.environ["WORLD_SIZE"])
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
 
-        if torch.cuda.is_available():
+        if device_type == "xpu":
+            torch.xpu.set_device(local_rank)
+            device = torch.device("xpu", local_rank)
+            dist_backend = "ccl"
+        elif device_type == "cuda":
             torch.cuda.set_device(local_rank)
             device = torch.device("cuda", local_rank)
             dist_backend = backend
@@ -58,7 +75,10 @@ def init_distributed_and_get_device(backend: str = "nccl"):
         if not dist.is_initialized():
             dist.init_process_group(backend=dist_backend, init_method="env://")
     else:
-        if torch.cuda.is_available():
+        if device_type == "xpu":
+            device = torch.device("xpu", 0)
+            torch.xpu.set_device(device)
+        elif device_type == "cuda":
             device = torch.device("cuda", 0)
             torch.cuda.set_device(device)
         else:
@@ -223,6 +243,12 @@ def get_args():
         action='store_true',
         help='Disable action-branch 1D RoPE precompute path.',
     )
+    parser.add_argument(
+        '--device',
+        type=str,
+        default=None,
+        help="Device type: 'xpu', 'cuda', or 'cpu'. Auto-detects if not specified.",
+    )
 
     args = parser.parse_args()
 
@@ -233,7 +259,7 @@ if __name__ == "__main__":
     args = get_args()
     policy_metadata = dict(test_meta="Tau Policy Meta Data")
     
-    device, is_distributed, rank, local_rank, world_size = init_distributed_and_get_device()
+    device, is_distributed, rank, local_rank, world_size = init_distributed_and_get_device(device_type=args.device)
     
     actor = TauPolicyServer(
         args.host, args.port, policy_metadata,


### PR DESCRIPTION
What this PR do

- Add --device CLI flag to inference servers (xpu/cuda/cpu, auto-detect)
- Replace hard-coded CUDA calls with runtime device detection throughout
- Use device=None defaults with auto-detection in VAE, T5, TauPolicy
- Add _device_type() helper for device-agnostic torch.amp.autocast contexts
- Remove deprecated torch.cuda.amp imports, use torch.amp.autocast API
- Add device-agnostic sync_current_device() and _empty_device_cache() helpers
- Select distributed backend dynamically (ccl for XPU, nccl for CUDA)
- Fix attention() SDPA path to preserve input dtype instead of forcing bfloat16
- Relax flash_attention device assert to allow xpu
- Document --device flag usage in README

Tested on Intel Graphics [0xe211]: WanModel forward pass MSE = 0.0